### PR TITLE
Returned to string ids when calling Toot's methods.

### DIFF
--- a/extensions.lisp
+++ b/extensions.lisp
@@ -38,10 +38,6 @@ if it is a list then we decode the response and collect and return them as a lis
 
 (defmethod no-bot-p ((id string))
   "checks an account's bio and profile fields to see if they contain a NoBot tag"
-  (no-bot-p (parse-integer id)))
-
-(defmethod no-bot-p ((id integer))
-  "checks an account's bio and profile fields to see if they contain a NoBot tag"
   (no-bot-p (tooter:find-account (bot-client *bot*) id)))
 
 (defmethod no-bot-p ((account tooter:account))
@@ -54,14 +50,6 @@ if it is a list then we decode the response and collect and return them as a lis
 (defmethod no-bot-p ((mention tooter:mention))
   "checks account found in MENTION to see if they have NoBot set"
   (no-bot-p (tooter:find-account (bot-client *bot*) (tooter:id mention))))
-
-(defmethod tooter:find-account ((client tooter:client) (id string))
-  "because the api/objects return ID as strings, but tooter expects ID to be an integer"
-  (tooter:find-account client (parse-integer id)))
-
-(defmethod tooter:find-status ((client tooter:client) (id string))
-  "because the api/objects return ID as strings, but tooter expects ID to be an integer"
-  (tooter:find-status client (parse-integer id)))
 
 (defmethod reply ((status tooter:status) text &key include-mentions media cw sensitive visibility)
   "replies to a STATUS with TEXT. copies the visibility and content warning as the post it's replying to

--- a/extensions.lisp
+++ b/extensions.lisp
@@ -43,9 +43,12 @@ if it is a list then we decode the response and collect and return them as a lis
 (defmethod no-bot-p ((account tooter:account))
   "checks an account's bio and profile fields to see if they contain a NoBot tag"
   (or (cl-ppcre:scan *no-bot-regex* (tooter:note account))
-      (some #'identity (loop for (f . v) in (tooter:fields account)
-			     collect (or (cl-ppcre:scan *no-bot-regex* f)
-					 (cl-ppcre:scan *no-bot-regex* v))))))
+      (loop for field in (tooter:fields account)
+            for name = (tooter:name field)
+            for value = (tooter::value field)
+	    when (or (cl-ppcre:scan *no-bot-regex* name)
+                     (cl-ppcre:scan *no-bot-regex* value))
+            collect field)))
 
 (defmethod no-bot-p ((mention tooter:mention))
   "checks account found in MENTION to see if they have NoBot set"

--- a/glacier.lisp
+++ b/glacier.lisp
@@ -55,7 +55,7 @@ if BODY is not provided drops into a loop where we sleep until the user quits us
       ((and (string= (agetf parsed :event) "update")
 	    (slot-boundp *bot* 'on-update))
        (funcall (bot-on-update *bot*) 
-		(tooter:find-status (bot-client *bot*) (parse-integer (agetf parsed-payload :id)))))
+		(tooter:find-status (bot-client *bot*) (agetf parsed-payload :id))))
       
       ((and (string= (agetf parsed :event) "delete")
 	    (slot-boundp *bot* 'on-delete))
@@ -66,7 +66,7 @@ if BODY is not provided drops into a loop where we sleep until the user quits us
        ;; we go ahead and get the notification object through tooter
        ;;  for ease of parsing, plus we were gonna get it anyway so
        ;;   :shrug:
-       (let ((notif (tooter:find-notification (bot-client *bot*) (parse-integer (agetf parsed-payload :id)))))
+       (let ((notif (tooter:find-notification (bot-client *bot*) (agetf parsed-payload :id))))
 	 (if (and
 	      ;; just some trickery to ensure that if we get a mention, to run
 	      ;;  our command dispatch.


### PR DESCRIPTION
Toot started using strings instead of integers since this commit:

https://github.com/Shinmera/tooter/commit/b4d049406316fb573171ef6bb6c840c2a1b56086

This pull fixes issue https://github.com/compufox/glacier/issues/4