### PR TITLE
Move definition of *bot* from glacier.lisp to util.lisp

### DIFF
--- a/glacier.lisp
+++ b/glacier.lisp
@@ -2,7 +2,6 @@
 
 (in-package #:glacier)
 
-(defvar *bot*)
 (defvar *websocket-client*)
 
 (defmacro run-bot ((bot &key delete-command (with-websocket t)) &body body)

--- a/util.lisp
+++ b/util.lisp
@@ -3,6 +3,8 @@
 (declaim (inline fave-p boost-p mention-p follow-p poll-ended-p
 		 follow-request-p bot-post-p agetf))
 
+(defvar *bot*)
+
 (defun parse-time (amount duration)
   "parses AMOUNT of DURATION into seconds"
   (* amount (cond


### PR DESCRIPTION
The predicates defined lower in util.lisp reference *bot*, but since
util.lisp is loaded before glacier.lisp, it generates a compiler warning.